### PR TITLE
Fixes a small visual bug in the footer.

### DIFF
--- a/openAPE/server/src/main/java/org/openape/ui/velocity/organism/Organism_5_Footer.java
+++ b/openAPE/server/src/main/java/org/openape/ui/velocity/organism/Organism_5_Footer.java
@@ -3,9 +3,8 @@ package org.openape.ui.velocity.organism;
 public class Organism_5_Footer {
     public String generateFooter() {
         final String footerContent = "\u00a9 Hochschule der Medien / Stuttgart Media University 2017 <br>"
-        		+ " <a href=' https://gpii.eu/legal/en/privacy.html'>Privacy</a> <br>"
-        		+ " <a href='https://gpii.eu/legal/en/imprint.html'>Imprint</a> "
-        		;
+        		+ "<a href='https://gpii.eu/legal/en/privacy.html'>Privacy</a>" 
+        		+ "<a href='https://gpii.eu/legal/en/imprint.html'>Imprint</a>";
         return footerContent;
     }
 }

--- a/openAPE/server/src/main/resources/webcontent/css/style.css
+++ b/openAPE/server/src/main/resources/webcontent/css/style.css
@@ -197,6 +197,8 @@ div.tab button.active {
   background-color: #3b3b3b; }
   #footer a {
     color: #e31134; }
+    #footer a:not(:last-of-type) {
+    margin-right: 1em; }
 
 .content {
   padding-bottom: 60px;

--- a/openAPE/server/src/main/resources/webcontent/scss/footer.scss
+++ b/openAPE/server/src/main/resources/webcontent/scss/footer.scss
@@ -16,6 +16,9 @@
    
    	a {
 		color: #e31134;
+      &:not(:last-of-type) {
+         margin-right: 1em;
+      }
 	}
 }
 


### PR DESCRIPTION
The two footer links to the legal resources where shown below each other due to the`<br>`. This caused the second link to be outside the visual region of the footer. Now the links are right to each other with an appropriate visual margin.