### PR TITLE
More space around Privacy, Imprint links in footer

### DIFF
--- a/openAPE/server/src/main/resources/webcontent/css/style.css
+++ b/openAPE/server/src/main/resources/webcontent/css/style.css
@@ -186,7 +186,7 @@ div.tab button.active {
 #footer {
   text-align: center;
   border-top: 4px solid #740a1b;
-  padding: 2em;
+  padding: 1em 2em 1em 2em;
   color: white;
   font-weight: bold;
   position: absolute;


### PR DESCRIPTION
#footer had padding: 2em; this pushed the bottom link (Imprint) out of the footer container. Reducing padidng-top and padding-bottom should solve this.